### PR TITLE
Update TRL CARLA example path after examples/ reorg

### DIFF
--- a/scripts/carla_vlm_gemma.py
+++ b/scripts/carla_vlm_gemma.py
@@ -38,7 +38,7 @@ pip install "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego
 
 Usage (requires at least 2 CARLA Spaces, each supports only 1 concurrent connection):
 ```sh
-python examples/scripts/openenv/carla_vlm.py \
+python examples/grpo_carla/carla_vlm.py \
     --env-urls https://server1.hf.space https://server2.hf.space
 ```
 """


### PR DESCRIPTION
Follow-up to huggingface/trl#6820: TRL's `examples/` was reorganized into self-contained per-example folders, so links to the old `examples/scripts/...` paths will 404 once it merges. This updates them to the new locations.